### PR TITLE
Regex fixing

### DIFF
--- a/requirement_walker/regex_expressions.py
+++ b/requirement_walker/regex_expressions.py
@@ -10,6 +10,9 @@ import re
 # Used to seperate the important part from the comments on each line.
 LINE_COMMENT_PATTERN = re.compile(r"^(?P<reqs>[^\r\n]*?)(?:\s*)(?P<comment> #.*)?$")
 
+# Used to find lines with only comments
+COMMENT_ONLY_PATTERN = re.compile(r"^(?P<comment>[ ]*#.*)$")
+
 # Used to pull out -r or --requirement files
 # Works for multi `-r`s in a single line
 # WORKS: -r test.txt -r ./path/test2.txt --requirement=oops.txt --requirement  C:\oops.txt

--- a/requirement_walker/regex_expressions.py
+++ b/requirement_walker/regex_expressions.py
@@ -8,7 +8,7 @@ import re
 # Owned
 
 # Used to seperate the important part from the comments on each line.
-LINE_COMMENT_PATTERN = re.compile(r"^(?P<reqs>[^#\r\n]*?)(?:\s*)(?P<comment>#.*)?$")
+LINE_COMMENT_PATTERN = re.compile(r"^(?P<reqs>[^\r\n]*?)(?:\s*)(?P<comment> #.*)?$")
 
 # Used to pull out -r or --requirement files
 # Works for multi `-r`s in a single line

--- a/requirement_walker/walker.py
+++ b/requirement_walker/walker.py
@@ -36,7 +36,7 @@ class Comment:
         Constructor
         ARGS:
             comment_str (str): A string which represent a comment in the requirements.txt
-                file. The comment should start with `#`.
+                file. The comment should start with ` #`.
         """
         self._comment_str = comment_str
          # Stripping for good measure

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import subprocess
 from setuptools import setup, find_packages
 
 NAME = 'requirement-walker'
-VERSION = '0.0.8'
+VERSION = '0.0.9'
 AUTHOR = 'Alex Guckenberger'
 AUTHOR_EMAIL = 'aguckenberger@mmm.com'
 DESCRIPTION = 'Walk through requirements and comments in requirements.txt files.'

--- a/tests/examples/requirements.txt
+++ b/tests/examples/requirements.txt
@@ -9,3 +9,4 @@ certifi==2020.11.8
 cffi==1.14.4
 ./pip_packages/orm_models # requirement-walker: local-package-name
 orm @ git+ssh://git@github.com/ORG/orm.git@5e2b6d14f00ffbd473dfe8b8602b79e37266568c # git link
+package.common @ git+ssh://git@github.com/ORG/package.git@master#egg=package.common&subdirectory=pip_packages/package-common # a comment

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -23,7 +23,10 @@ def test_simple_assertions(examples_path):
 def test_simple_req_file(examples_path):
     """ Test the sole requirements.txt file """
     entries = list(RequirementFile(examples_path / './requirements.txt'))
-    assert len(entries) == 11
+    assert len(entries) == 12
+    # with open("temp.txt", 'w') as f:
+    #     entries = [str(entry) + '\n' for entry in entries]
+    #     f.writelines(entries)  
 
 def test_recursive_iter(examples_path):
     """ Use the walker and make some simple assertions. """

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -24,9 +24,6 @@ def test_simple_req_file(examples_path):
     """ Test the sole requirements.txt file """
     entries = list(RequirementFile(examples_path / './requirements.txt'))
     assert len(entries) == 12
-    # with open("temp.txt", 'w') as f:
-    #     entries = [str(entry) + '\n' for entry in entries]
-    #     f.writelines(entries)  
 
 def test_recursive_iter(examples_path):
     """ Use the walker and make some simple assertions. """


### PR DESCRIPTION
Egg specification means comments on a requirement line MUST start with a space. I didn't account for this.

Example requirement where it failed before.

**Input**
```
package.common @ git+ssh://git@github.com/ORG/package.git@master#egg=distillery_common&subdirectory=pip_packages/package-common # An actual comment
```

**Past Output** (Note the space before the #egg)
```
package.common@ git+ssh://git@github.com/ORG/distillery.git@master #egg=package.common&subdirectory=pip_packages/package-common # An actual comment
```

**New Output**
```
package.common@ git+ssh://git@github.com/ORG/package.git@master#egg=package.common&subdirectory=pip_packages/package-common # a comment
```
